### PR TITLE
Disable some rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = {
 
         "array-callback-return": 2,
         "block-scoped-var": 2,
-        "complexity": [1, 10],
+        "complexity": 0,
         "no-alert": 2,
         "no-caller": 2,
         "no-console": ["error", {allow: ["info", "warn", "error"]}],
@@ -103,6 +103,8 @@ module.exports = {
         // jasmine
         "jasmine/new-line-before-expect": 0,
         "jasmine/new-line-between-declarations": 0,
+        "jasmine/prefer-toHaveBeenCalledWith": 0,
+        "jasmine/no-promise-without-done-fail": 0, // keep code concise, let it time out
 
         // style
         "array-bracket-spacing": [2, "never"],


### PR DESCRIPTION
* complexity - I'd rather have complexity checked by developers during code review. I don't think a rule can evaluate complexity well. For example it threw a warning this [this code](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/authoring/preview/getAuthoringField.ts) which is long and has many cases, but I don't see a better way to write it.
* jasmine/prefer-toHaveBeenCalledWith - not important, adds noise to lint output
* jasmine/no-promise-without-done-fail - keep code concise, let it time out